### PR TITLE
Persist the zone details used for cluster creation across jobs.

### DIFF
--- a/script/gke
+++ b/script/gke
@@ -25,6 +25,7 @@ mkdir /openebs/e2e-gke/.kube
 cat ~/.kube/config > /openebs/e2e-gke/.kube/config
 cat ~/.kube/config > /openebs/e2e-gke/.kube/admin.conf
 cat ~/logs/clusters > /openebs/e2e-gke/.kube/clusters
+cat ~/logs/clusters > /openebs/e2e-gke/.kube/zone
 
 kubectl get nodes
 wget https://raw.githubusercontent.com/openebs/litmus/master/hack/rbac.yaml

--- a/script/gke-cleanup
+++ b/script/gke-cleanup
@@ -11,6 +11,7 @@ export GCP_SERVICE_ACCOUNT_FILE="/openebs/e2e-gke/key.json"
 echo "cleanup"
 mkdir ~/logs
 cp .kube/clusters ~/logs
+cp .kube/zone ~/logs
 git clone https://github.com/openebs/litmus.git 
 cd litmus/k8s/gke/k8s-installer/
 echo "cleanup"

--- a/script/utils/setup_dependencies
+++ b/script/utils/setup_dependencies
@@ -12,6 +12,7 @@ derive_cluster_details_infra()
  ## Transfer cluster config & physical details into '.kube-openebs'
  cp  .kube/config ~/.kube/config
  cat /openebs/e2e-gke/.kube/clusters > .kube-openebs/clusters
+ cat /openebs/e2e-gke/.kube/zone > .kube-openebs/zone
 }
  
 setup_cluster_config_test()
@@ -20,6 +21,7 @@ setup_cluster_config_test()
  cp .kube-openebs/config ~/.kube/config
  mkdir ~/logs
  cp .kube-openebs/clusters ~/logs
+ cp .kube-openebs/zone ~/logs
 }
 
 if [[ $1 == "infra-setup" ]]; then


### PR DESCRIPTION
- Create zone file to persist the zone details used for creating the
cluster.

Signed-off-by: Uday Kiran Y <uday.kiran@openebs.io>